### PR TITLE
feat: register page, CustomTextfield

### DIFF
--- a/src/components/CustomTextfield.tsx
+++ b/src/components/CustomTextfield.tsx
@@ -1,0 +1,5 @@
+import { TextField, TextFieldProps } from '@mui/material';
+
+export function CustomTextfield(prop: TextFieldProps) {
+  return <TextField size="small" InputProps={{ style: { backgroundColor: 'white', borderRadius: 10 } }} {...prop} />;
+}

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,3 +1,177 @@
-export default function RegisterPage() {
-  return <div>Register</div>;
+import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import axios from 'axios';
+import { Box, Button, Divider, Stack, Typography } from '@mui/material';
+
+import { CustomTextfield } from '../components/CustomTextfield';
+
+/**
+ * 유저 생성 페이지입니다.
+ * 회원가입을 위한 정보를 입력받습니다.
+ * 회원가입 버튼을 누르면 백엔드 서버에 회원가입 요청을 보냅니다.
+ */
+export function RegisterPage() {
+  const [input, setInput] = useState({
+    email: '',
+    membername: '',
+    password: '',
+    passwordConfirm: '',
+  });
+
+  const [errMessage, setErrMessage] = useState({
+    email: '',
+    membername: '',
+    password: '',
+    passwordConfirm: '',
+  });
+
+  const [isErr, setIsErr] = useState({
+    email: false,
+    membername: false,
+    password: false,
+    passwordConfirm: false,
+  });
+  const navigate = useNavigate();
+
+  function onChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setInput({
+      ...input,
+      [event.target.id]: event.target.value,
+    });
+    const message = validation(event.target.value, event.target.id);
+    if (message) {
+      setErrMessage({
+        ...errMessage,
+        [event.target.id]: message,
+      });
+      setIsErr({
+        ...isErr,
+        [event.target.id]: true,
+      });
+    } else {
+      setErrMessage({
+        ...errMessage,
+        [event.target.id]: '',
+      });
+      setIsErr({
+        ...isErr,
+        [event.target.id]: false,
+      });
+    }
+  }
+  function validation(value: string, id: string): string {
+    const emailErrMessage = '이메일 형식으로 작성해주세요.';
+    const emailLenErrMessage = '64자 이하여야 합니다.';
+    const pwErrMessage = '적어도 하나 이상의 영문자, 숫자가 필요하며 8자 이상 입력해주세요.';
+    const pwConErrMessage = '비밀번호와 일치하지 않습니다.';
+    const emailRegExp = /^[a-zA-z0-9._-]+@[a-zA-z0-9.-]+\.[a-zA-z.]+$/;
+    const passwordRegExp = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$/;
+    if (id === 'email') {
+      if (value.length > 64) return emailLenErrMessage;
+      if (!emailRegExp.test(value)) return emailErrMessage;
+    }
+    if (id === 'password' && !passwordRegExp.test(value)) return pwErrMessage;
+    if (id === 'passwordConfirm' && input.password !== value) return pwConErrMessage;
+    return '';
+  }
+
+  async function handleRegister() {
+    try {
+      if (Object.values(input).some((value) => value === '')) window.alert('내용을 입력하시기 바랍니다.');
+      else if (Object.values(isErr).some((value) => value)) window.alert('요구사항을 충족하지 않았습니다.');
+      else {
+        const response = await axios.post(
+          `${process.env.REACT_APP_API_URL}auth/register`,
+          { email: input.email, membername: input.membername, password: input.password },
+          {
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          },
+        );
+
+        if (response.status === 200) {
+          window.alert('회원가입이 완료되었습니다.');
+          navigate('/');
+        }
+      }
+    } catch (e) {
+      window.alert('회원가입에 실패했습니다.');
+    }
+  }
+
+  return (
+    <Box
+      padding={2}
+      paddingTop={4}
+      width={400}
+      marginTop={10}
+      marginX="auto"
+      boxShadow="0px 4px 8px rgba(0, 0, 0, 0.2)"
+    >
+      <Box marginBottom={4} textAlign={'center'}>
+        <Typography variant="h4">Register</Typography>
+      </Box>
+      <Box>
+        <Box marginY={2}>
+          <Divider />
+        </Box>
+        <Stack spacing={3}>
+          <CustomTextfield
+            error={isErr.email}
+            helperText={errMessage.email}
+            required={true}
+            id="email"
+            label="e-mail"
+            onChange={onChange}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') handleRegister();
+            }}
+          />
+          <CustomTextfield
+            type="password"
+            error={isErr.password}
+            helperText={errMessage.password}
+            required={true}
+            id="password"
+            label="비밀번호"
+            onChange={onChange}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') handleRegister();
+            }}
+          />
+
+          <CustomTextfield
+            type="password"
+            error={isErr.passwordConfirm}
+            helperText={errMessage.passwordConfirm}
+            required={true}
+            id="passwordConfirm"
+            label="비밀번호 확인"
+            onChange={onChange}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') handleRegister();
+            }}
+          />
+
+          <CustomTextfield
+            error={isErr.membername}
+            helperText={errMessage.membername}
+            required={true}
+            id="membername"
+            label="이름"
+            onChange={onChange}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') handleRegister();
+            }}
+          />
+        </Stack>
+      </Box>
+      <Box paddingY={6} marginX={'auto'} width={350}>
+        <Button fullWidth variant="contained" color="primary" onClick={handleRegister}>
+          회원 가입
+        </Button>
+      </Box>
+    </Box>
+  );
 }

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -10,7 +10,7 @@ import { CustomTextfield } from '../components/CustomTextfield';
  * 회원가입을 위한 정보를 입력받습니다.
  * 회원가입 버튼을 누르면 백엔드 서버에 회원가입 요청을 보냅니다.
  */
-export function RegisterPage() {
+export default function RegisterPage() {
   const [input, setInput] = useState({
     email: '',
     membername: '',


### PR DESCRIPTION
## 추가한 점
- 회원가입 페이지
- CustomTextfield 컴포넌트

### 1. 회원가입 페이지
App에서 <Layout> 지웠을 때 모습
![image](https://github.com/KWEBofficial/anytime-client/assets/80162729/d3e2a5da-3cdb-42f3-b62a-798150acdd0b)

#### validation
이메일 부분
/^[a-zA-z0-9._-]+@[a-zA-z0-9.-]+\.[a-zA-z.]+$/형태가 아닐 시 '이메일 형식으로 작성해주세요.' 출력
길이가 64자 이상이 되면 '64자 이하여야 합니다.' 출력
![image](https://github.com/KWEBofficial/anytime-client/assets/80162729/5529081c-f323-4dcd-97cf-5604c77768df)
![image](https://github.com/KWEBofficial/anytime-client/assets/80162729/208bb001-2a89-4e07-8314-5caedd432b9a)

비밀번호 부분
/^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$/가 아닐 시 '적어도 하나 이상의 영문자, 숫자가 필요하며 8자 이상 입력해주세요.' 출력
![image](https://github.com/KWEBofficial/anytime-client/assets/80162729/3635bc0e-ff62-42f9-ad8a-2ef11c4a8887)

비밀번호 확인 부분
비밀번호와 일치하지 않을 시 '비밀번호와 일치하지 않습니다.'출력
![image](https://github.com/KWEBofficial/anytime-client/assets/80162729/c3b0e6fb-3baf-453b-8d20-2310aba1ec2e)

이름 부분
여기는 validation을 하지 않았음. 

#### 회원가입 요청
회원가입 버튼을 누르거나 입력창에서 enter 누를 시 요청
하나라도 요구사항을 만족 못했을 때
![image](https://github.com/KWEBofficial/anytime-client/assets/80162729/8ba17b7a-b2f1-44b7-a84d-12d60b17f51e)

다 만족하였을 때 '/'경로로 이동
![image](https://github.com/KWEBofficial/anytime-client/assets/80162729/8f526e92-a631-4aaa-982b-52b849a25642)
![image](https://github.com/KWEBofficial/anytime-client/assets/80162729/aa2b43dc-7324-436d-aa84-40f1b20b2244)

### 2. CustomTextfield 컴포넌트
`size="small" InputProps={{ style: { backgroundColor: 'white', borderRadius: 10 } }}` 를 Textfield 컴포넌트에 추가한 것이 다임... 뭔가 시도해 봤지만 Textfield가 잘 되어 있어서 다 지웠음. 뭘 어떻게 해야 Custom했다고 할 수 있을지 모르겠음...



