### PR TITLE
feat: create favorite team schedule component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react-dom": "^18.2.18",
         "axios": "^1.6.3",
         "cross-env": "^7.0.3",
+        "date-fns": "^3.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.21.1",
@@ -6694,6 +6695,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.2.0.tgz",
+      "integrity": "sha512-E4KWKavANzeuusPi0jUjpuI22SURAznGkx7eZV+4i6x2A+IZxAMcajgkvuDAU1bg40+xuhW1zRdVIIM/4khuIg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -21936,6 +21946,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "date-fns": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.2.0.tgz",
+      "integrity": "sha512-E4KWKavANzeuusPi0jUjpuI22SURAznGkx7eZV+4i6x2A+IZxAMcajgkvuDAU1bg40+xuhW1zRdVIIM/4khuIg=="
     },
     "debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/react-dom": "^18.2.18",
     "axios": "^1.6.3",
     "cross-env": "^7.0.3",
+    "date-fns": "^3.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.1",

--- a/src/components/FavorTeam/FavorTeam.tsx
+++ b/src/components/FavorTeam/FavorTeam.tsx
@@ -1,0 +1,235 @@
+import React, { useEffect, useState } from 'react';
+import { format } from 'date-fns';
+import { Grid, Stack, List, ListItemText, Typography, ListItem, Divider } from '@mui/material';
+
+interface Schedule {
+  name: string;
+  startDate: Date;
+  endDate: Date;
+  explanation: string;
+}
+
+interface MyTeamSche {
+  teamname: string;
+  isFavor: boolean;
+  isHide: boolean;
+  schedule: Schedule[];
+}
+
+export default function FavorTeam() {
+  const [favor, setFavor] = useState<MyTeamSche[]>([
+    {
+      teamname: 'test1',
+      isFavor: true,
+      isHide: false,
+      schedule: [
+        {
+          name: 'sche1',
+          startDate: new Date(),
+          endDate: new Date(),
+          explanation: 'sche1',
+        },
+        {
+          name: 'sche2',
+          startDate: new Date(),
+          endDate: new Date(),
+          explanation: 'sche2',
+        },
+      ],
+    },
+    {
+      teamname: 'not Favor test',
+      isFavor: false,
+      isHide: false,
+      schedule: [
+        {
+          name: 'not Favor sche1',
+          startDate: new Date(),
+          endDate: new Date(),
+          explanation: 'not Favor sche1',
+        },
+      ],
+    },
+    {
+      teamname: 'check it out',
+      isFavor: true,
+      isHide: false,
+      schedule: [
+        {
+          name: 'check11111111111111',
+          startDate: new Date('2024-01-11'),
+          endDate: new Date('2024-01-12'),
+          explanation: 'check that it should not be appeared at FavorTeam scheBox',
+        },
+        {
+          name: 'check222222222222',
+          startDate: new Date('2024-01-11'),
+          endDate: new Date('2024-01-14'),
+          explanation: 'Check that it should be appeared at FavorTeam scheBox.',
+        },
+        {
+          name: 'check3',
+          startDate: new Date('2024-01-14'),
+          endDate: new Date('2024-01-14'),
+          explanation: 'Check that it should be appeared at FavorTeam scheBox.',
+        },
+        {
+          name: 'check4',
+          startDate: new Date('2024-01-15'),
+          endDate: new Date('2024-01-19'),
+          explanation: 'Check that it should be appeared at FavorTeam scheBox.',
+        },
+        {
+          name: 'check5',
+          startDate: new Date('2024-01-17'),
+          endDate: new Date('2024-01-17'),
+          explanation: 'Check that it should be appeared at FavorTeam scheBox.',
+        },
+        {
+          name: 'check6',
+          startDate: new Date('2024-01-22'),
+          endDate: new Date('2024-01-22'),
+          explanation: 'Check that it should be appeared at FavorTeam scheBox.',
+        },
+        {
+          name: 'check7',
+          startDate: new Date('2024-01-22'),
+          endDate: new Date('2024-01-24'),
+          explanation: 'Check that it should be appeared at FavorTeam scheBox.',
+        },
+      ],
+    },
+  ]);
+
+  useEffect(() => {
+    setFavor((curr) => curr);
+  }, []);
+
+  useEffect(() => {
+    setFavor((curr) => [
+      ...curr,
+      {
+        teamname: 'test2',
+        isFavor: true,
+        isHide: false,
+        schedule: [
+          {
+            name: 'test2',
+            startDate: new Date(),
+            endDate: new Date(),
+            explanation: 'test2',
+          },
+        ],
+      },
+    ]);
+  }, []);
+
+  console.log('favor: ');
+  favor.forEach((f) => console.log(f.teamname));
+
+  const validTeam: MyTeamSche[] = [];
+  for (let i = 0; i < favor.length; i += 1) {
+    if (validTeam.length === 3) break;
+    if (favor[i].isFavor === true && favor[i].isHide === false) {
+      validTeam.push(favor[i]);
+    }
+  }
+  const validSche = validTeam.map<MyTeamSche>((team) => {
+    return {
+      teamname: team.teamname,
+      isFavor: team.isFavor,
+      isHide: team.isHide,
+      schedule: team.schedule
+        .filter((sche) => {
+          return format(sche.endDate, 'y-M-d') >= format(new Date(), 'y-M-d');
+        })
+        .sort((a, b) => (format(a.startDate, 'y-M-d') <= format(b.startDate, 'y-M-d') ? -1 : 1)),
+    };
+  });
+
+  const scheBox = [];
+  for (let i = 0; i < validSche.length; i += 1) {
+    scheBox.push(
+      <Grid>
+        <List
+          sx={{
+            bgcolor: '#cfe8fc',
+            width: '20vw',
+            height: '50vh',
+            borderRadius: '20px',
+            fontSize: '4vh',
+            fontWeight: 'bold',
+            boxShadow: 3,
+            overflow: 'hidden',
+            [`&.MuiList-root:hover`]: {
+              transition: '0.2s ease-in-out',
+              transform: 'scale(1.05)',
+              boxShadow: '4',
+            },
+            [`&.MuiList-root:not(:hover)`]: { transition: '0.2s ease-in-out', transfrom: 'scale(1)' },
+          }}
+        >
+          <li key={validSche[i].teamname}>
+            <ListItem>{validSche[i].teamname}</ListItem>
+
+            <Divider />
+
+            {validSche[i].schedule.map((sche) => (
+              <ListItem
+                sx={{
+                  paddingTop: 0.5,
+                  paddingBottom: 0,
+                  width: '20vw',
+                }}
+              >
+                <ListItemText
+                  primary={
+                    <Typography
+                      component="div"
+                      variant="body2"
+                      color="text.primary"
+                      width={'100%'}
+                      sx={{
+                        fontSize: '2vh',
+                        fontWeight: '800',
+                      }}
+                    >
+                      {sche.name}
+                    </Typography>
+                  }
+                  secondary={
+                    <React.Fragment>
+                      <Typography
+                        sx={{ display: 'inline', fontSize: '1.6vh', fontWeight: 'bold' }}
+                        component="div"
+                        variant="body2"
+                        color="text.primary"
+                      >
+                        {format(sche.startDate, 'y-M-d') === format(sche.endDate, 'y-M-d')
+                          ? `${format(sche.startDate, 'y년 M월 d일 HH:MM')} ~ ${format(sche.endDate, 'HH:MM')}`
+                          : `${format(sche.startDate, 'y년 M월 d일 HH:MM')} ~ ${format(
+                              sche.endDate,
+                              'yy년 MM월 dd일 HH:MM',
+                            )}`}
+                      </Typography>
+                      <Typography sx={{ fontSize: '1.5vh', fontWeight: 'bold' }}>{sche.explanation}</Typography>
+                    </React.Fragment>
+                  }
+                ></ListItemText>
+              </ListItem>
+            ))}
+          </li>
+        </List>
+      </Grid>,
+    );
+  }
+
+  console.log('validSche: ');
+  validTeam.forEach((f) => console.log(f.teamname));
+
+  return (
+    <Stack display={'flex'} justifyContent={'center'} direction={'row'} spacing={10} width={'88vw'}>
+      {scheBox}
+    </Stack>
+  );
+}

--- a/src/components/FavorTeamSche/FavorTeamSche.tsx
+++ b/src/components/FavorTeamSche/FavorTeamSche.tsx
@@ -16,7 +16,7 @@ interface MyTeamSche {
   schedule: Schedule[];
 }
 
-export default function FavorTeam() {
+export default function FavorTeamSche() {
   const [favor, setFavor] = useState<MyTeamSche[]>([
     {
       teamname: 'test1',
@@ -104,7 +104,7 @@ export default function FavorTeam() {
   useEffect(() => {
     setFavor((curr) => curr);
   }, []);
-
+  /*
   useEffect(() => {
     setFavor((curr) => [
       ...curr,
@@ -123,10 +123,7 @@ export default function FavorTeam() {
       },
     ]);
   }, []);
-
-  console.log('favor: ');
-  favor.forEach((f) => console.log(f.teamname));
-
+  */
   const validTeam: MyTeamSche[] = [];
   for (let i = 0; i < favor.length; i += 1) {
     if (validTeam.length === 3) break;
@@ -143,7 +140,7 @@ export default function FavorTeam() {
         .filter((sche) => {
           return format(sche.endDate, 'y-M-d') >= format(new Date(), 'y-M-d');
         })
-        .sort((a, b) => (format(a.startDate, 'y-M-d') <= format(b.startDate, 'y-M-d') ? -1 : 1)),
+        .sort((a, b) => (format(a.startDate, 'y-M-d') < format(b.startDate, 'y-M-d') ? -1 : 1)),
     };
   });
 
@@ -223,9 +220,6 @@ export default function FavorTeam() {
       </Grid>,
     );
   }
-
-  console.log('validSche: ');
-  validTeam.forEach((f) => console.log(f.teamname));
 
   return (
     <Stack display={'flex'} justifyContent={'center'} direction={'row'} spacing={10} width={'88vw'}>

--- a/src/components/FavorTeamSche/FavorTeamSche.tsx
+++ b/src/components/FavorTeamSche/FavorTeamSche.tsx
@@ -65,7 +65,7 @@ export default function FavorTeamSche() {
           name: 'check222222222222',
           startDate: new Date('2024-01-11'),
           endDate: new Date('2024-01-14'),
-          explanation: 'Check that it should be appeared at FavorTeam scheBox.',
+          explanation: 'Check that it should be appeared at FavorTeam scheBox. string이 칸을 넘어갈 경우 공백을 기준으로 줄바꿈이 이루어짐.',
         },
         {
           name: 'check3',
@@ -203,10 +203,10 @@ export default function FavorTeamSche() {
                         color="text.primary"
                       >
                         {format(sche.startDate, 'y-M-d') === format(sche.endDate, 'y-M-d')
-                          ? `${format(sche.startDate, 'y년 M월 d일 HH:MM')} ~ ${format(sche.endDate, 'HH:MM')}`
-                          : `${format(sche.startDate, 'y년 M월 d일 HH:MM')} ~ ${format(
+                          ? `${format(sche.startDate, 'yy년 MM월 dd일 hh:mm')} ~ ${format(sche.endDate, 'hh:mm')}`
+                          : `${format(sche.startDate, 'yy년 MM월 dd일 hh:mm')} ~ ${format(
                               sche.endDate,
-                              'yy년 MM월 dd일 HH:MM',
+                              'yy년 MM월 dd일 hh:mm',
                             )}`}
                       </Typography>
                       <Typography sx={{ fontSize: '1.5vh', fontWeight: 'bold' }}>{sche.explanation}</Typography>


### PR DESCRIPTION
## 추가한 점
- `FavorTeamSche` component
: 메인페이지에서 즐겨찾기한 그룹의 다음 모임 일정을 확인할 수 있는 컴포넌트

![111](https://github.com/KWEBofficial/anytime-client/assets/97330728/524dac72-36cc-40e9-ad1c-1d9b649d9e66)
![222](https://github.com/KWEBofficial/anytime-client/assets/97330728/45de4f62-881f-4e7a-9765-0d4ab0f4de70)
![333](https://github.com/KWEBofficial/anytime-client/assets/97330728/efebaaf8-0d81-4cc8-87a9-3c18b292ccb8)
최대 3개의 박스까지 표시 가능합니다.

![444](https://github.com/KWEBofficial/anytime-client/assets/97330728/3f1c5c4b-305e-4aa0-af41-cef7b2f04640)
마우스 hover 애니메이션을 구현하였습니다.

## 참고할 점
- 즐겨찾기한 모임 최대 3개까지 표시 가능하며, 그룹이 나타나는 순서는 오래된 순서입니다.
- 스케쥴의 endDate가 금일보다 늦을 경우 리스트에 표시되며, 스케쥴 정렬 순서는 startDate 오름차순입니다.
- 표시되어야 할 일정이 칸을 넘어갈 경우, `overflow={hidden}`으로 설정하여 보이지 않게 설정하였습니다.
## 논의할 점
