### PR TITLE
feat: private page, side bar

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },
-  "eslint.validate": ["javascript"]
+  "eslint.validate": ["javascript"],
+  "cSpell.words": ["notistack"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "axios": "^1.6.3",
         "cross-env": "^7.0.3",
         "date-fns": "^3.2.0",
+        "notistack": "^3.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.21.1",
@@ -9194,6 +9195,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.14.tgz",
+      "integrity": "sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -11893,6 +11902,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/notistack": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-3.0.1.tgz",
+      "integrity": "sha512-ntVZXXgSQH5WYfyU+3HfcXuKaapzAJ8fBLQ/G618rn3yvSzEbnOB8ZSOwhX+dAORy/lw+GC2N061JA0+gYWTVA==",
+      "dependencies": {
+        "clsx": "^1.1.0",
+        "goober": "^2.0.33"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/notistack"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/notistack/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/npm-run-path": {
@@ -23778,6 +23816,12 @@
         "slash": "^3.0.0"
       }
     },
+    "goober": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.14.tgz",
+      "integrity": "sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==",
+      "requires": {}
+    },
     "gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -25751,6 +25795,22 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
+    },
+    "notistack": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-3.0.1.tgz",
+      "integrity": "sha512-ntVZXXgSQH5WYfyU+3HfcXuKaapzAJ8fBLQ/G618rn3yvSzEbnOB8ZSOwhX+dAORy/lw+GC2N061JA0+gYWTVA==",
+      "requires": {
+        "clsx": "^1.1.0",
+        "goober": "^2.0.33"
+      },
+      "dependencies": {
+        "clsx": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+          "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+        }
+      }
     },
     "npm-run-path": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "axios": "^1.6.3",
     "cross-env": "^7.0.3",
     "date-fns": "^3.2.0",
+    "notistack": "^3.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { RecoilRoot } from 'recoil';
 import { BrowserRouter } from 'react-router-dom';
+import { SnackbarProvider } from 'notistack';
 import { ThemeProvider, createTheme } from '@mui/material';
 
 import { RouteComponent } from './route';
@@ -25,13 +26,15 @@ const theme = createTheme({
  */
 function App() {
   return (
-    <RecoilRoot>
-      <ThemeProvider theme={theme}>
-        <BrowserRouter>
-          <RouteComponent />
-        </BrowserRouter>
-      </ThemeProvider>
-    </RecoilRoot>
+    <SnackbarProvider maxSnack={3}>
+      <RecoilRoot>
+        <ThemeProvider theme={theme}>
+          <BrowserRouter>
+            <RouteComponent />
+          </BrowserRouter>
+        </ThemeProvider>
+      </RecoilRoot>
+    </SnackbarProvider>
   );
 }
 

--- a/src/components/Calendar/style.scss
+++ b/src/components/Calendar/style.scss
@@ -3,8 +3,8 @@
 
 .calendar {
   @include common.size(100%, 100%);
-  height: 90vh;
-  width: 88vw;
+  height: 500px;
+  width: 700px;
   background-color: theme.$dashboard-color;
   .header {
     @include common.size(100%, 7%);

--- a/src/components/CustomBox.tsx
+++ b/src/components/CustomBox.tsx
@@ -24,7 +24,7 @@ const CustomBox = ({ title, items }: CustomBoxProps) => {
       </Typography>
       <List>
         {items.map((item) => (
-          <ListItem style={{ justifyContent: 'center' }}>
+          <ListItem key={item} style={{ justifyContent: 'center' }}>
             <Typography lineHeight={1}>{item}</Typography>
           </ListItem>
         ))}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,7 +1,8 @@
 import { useNavigate } from 'react-router-dom';
 import * as React from 'react';
 // import Typography from '@mui/material/Typography';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
 import Toolbar from '@mui/material/Toolbar';
 import ListItemText from '@mui/material/ListItemText';
 // import ListItemIcon from '@mui/material/ListItemIcon';
@@ -19,16 +20,26 @@ import AppBar from '@mui/material/AppBar';
 // import MailIcon from '@mui/icons-material/Mail';
 import SearchIcon from '@mui/icons-material/Search';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import AddIcon from '@mui/icons-material/Add';
 
 import ResponsiveAppBar from './TopNavigation';
 
 const drawerWidth = 180;
 
+interface TeamInfo {
+  teamId: number;
+  teamname: string;
+  isPublic: number;
+  isAdmin: number;
+  isFavor: number;
+  isHide: number;
+}
 export default function ClippedDrawer() {
   const navigate = useNavigate();
   const [openPrivate, setOpenPrivate] = useState(false);
   const [openPublic, setOpenPublic] = useState(false);
+  const [myTeam, setMyTeam] = useState<TeamInfo[]>([]);
 
   const handlePrivateClick = () => {
     setOpenPrivate(!openPrivate);
@@ -41,6 +52,31 @@ export default function ClippedDrawer() {
   const navigateToTeam = (teamId: number) => {
     navigate(`/team/${teamId}`);
   };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await axios.get(`${process.env.REACT_APP_API_URL}/team`, {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          withCredentials: true,
+        });
+
+        if (response.status === 200) {
+          setMyTeam(response.data);
+        }
+      } catch (e) {
+        /* empty */
+      }
+    };
+    fetchData();
+  }, []);
+
+  const publicTeamNames = myTeam.filter((team) => team.isPublic === 1).map((team) => team.teamname);
+  const publicTeamIds = myTeam.filter((team) => team.isPublic === 1).map((team) => team.teamId);
+  const privateTeamNames = myTeam.filter((team) => team.isPublic === 0).map((team) => team.teamname);
+  const privateTeamIds = myTeam.filter((team) => team.isPublic === 0).map((team) => team.teamId);
 
   return (
     <Box sx={{ display: 'flex' }}>
@@ -71,10 +107,10 @@ export default function ClippedDrawer() {
           <List>
             {['사적모임'].map((text) => (
               <React.Fragment key={text}>
-                <ListItem disablePadding>
+                <ListItem disablePadding onClick={handlePrivateClick}>
                   <ListItemButton>
                     <ListItemIcon sx={{ minWidth: 'auto', mr: 1 }} onClick={handlePrivateClick}>
-                      <ExpandMoreIcon />
+                      {openPrivate ? <ExpandLessIcon /> : <ExpandMoreIcon />}
                     </ListItemIcon>
                     <ListItemText primary={text} />
                     <ListItemIcon sx={{ minWidth: 'auto', mr: 0 }}>
@@ -83,12 +119,15 @@ export default function ClippedDrawer() {
                   </ListItemButton>
                 </ListItem>
                 <Collapse in={openPrivate} timeout="auto" unmountOnExit>
-                  <ListItemButton sx={{ pl: 4 }} onClick={() => navigateToTeam(1)}>
-                    <ListItemText primary="사적모임1" />
-                  </ListItemButton>
-                  <ListItemButton sx={{ pl: 4 }} onClick={() => navigateToTeam(2)}>
-                    <ListItemText primary="사적모임2" />
-                  </ListItemButton>
+                  {privateTeamNames.map((name, index) => (
+                    <ListItemButton
+                      key={privateTeamIds[index]}
+                      sx={{ pl: 4 }}
+                      onClick={() => navigateToTeam(privateTeamIds[index])}
+                    >
+                      <ListItemText primary={name} />
+                    </ListItemButton>
+                  ))}
                 </Collapse>
               </React.Fragment>
             ))}
@@ -97,10 +136,10 @@ export default function ClippedDrawer() {
           <List>
             {['공적모임'].map((text) => (
               <React.Fragment key={text}>
-                <ListItem disablePadding sx={{ '&:hover': { backgroundColor: 'transparent' } }}>
+                <ListItem disablePadding onClick={handlePublicClick}>
                   <ListItemButton>
                     <ListItemIcon sx={{ minWidth: 'auto', mr: 1 }} onClick={handlePublicClick}>
-                      <ExpandMoreIcon />
+                      {openPublic ? <ExpandLessIcon /> : <ExpandMoreIcon />}
                     </ListItemIcon>
                     <ListItemText primary={text} />
                     <ListItemIcon onClick={() => navigate('/team/search')} sx={{ minWidth: 'auto', mr: 1 }}>
@@ -112,12 +151,15 @@ export default function ClippedDrawer() {
                   </ListItemButton>
                 </ListItem>
                 <Collapse in={openPublic} timeout="auto" unmountOnExit>
-                  <ListItemButton sx={{ pl: 4 }} onClick={() => navigateToTeam(3)}>
-                    <ListItemText primary="공적모임1" />
-                  </ListItemButton>
-                  <ListItemButton sx={{ pl: 4 }} onClick={() => navigateToTeam(4)}>
-                    <ListItemText primary="공적모임2" />
-                  </ListItemButton>
+                  {publicTeamNames.map((name, index) => (
+                    <ListItemButton
+                      key={publicTeamIds[index]}
+                      sx={{ pl: 4 }}
+                      onClick={() => navigateToTeam(publicTeamIds[index])}
+                    >
+                      <ListItemText primary={name} />
+                    </ListItemButton>
+                  ))}
                 </Collapse>
               </React.Fragment>
             ))}

--- a/src/components/TeamExp.tsx
+++ b/src/components/TeamExp.tsx
@@ -12,6 +12,7 @@ const style = {
   color: '#696969',
   paddingLeft: 1,
   paddingRight: 1,
+  marginTop: 2,
 };
 
 interface TeamExpProps {

--- a/src/components/TeamTitle.tsx
+++ b/src/components/TeamTitle.tsx
@@ -14,7 +14,7 @@ export default function TeamTitle({ title }: TeamTitleProps) {
   return (
     <AppBar position="static" sx={{ backgroundColor: '#fff', boxShadow: 'none' }}>
       <Toolbar>
-        <Typography variant="h3" sx={{ color: '#696969', marginRight: '200px' }}>
+        <Typography variant="h3" sx={{ color: '#696969', marginRight: '300px', marginBottom: 2 }}>
           {title}
         </Typography>
         <IconButton sx={{ color: '#696969' }} aria-label="Edit">

--- a/src/components/TopNavigation.tsx
+++ b/src/components/TopNavigation.tsx
@@ -1,6 +1,7 @@
 import { useRecoilState } from 'recoil';
 import { useNavigate } from 'react-router-dom';
 import * as React from 'react';
+import { useSnackbar } from 'notistack';
 import axios from 'axios';
 import Typography from '@mui/material/Typography';
 import Tooltip from '@mui/material/Tooltip';
@@ -23,6 +24,7 @@ const settings = ['로그아웃'];
 function ResponsiveAppBar() {
   const navigate = useNavigate();
   const [, setLoginUser] = useRecoilState(userState);
+  const { enqueueSnackbar } = useSnackbar();
 
   const [anchorElNav, setAnchorElNav] = React.useState<null | HTMLElement>(null);
   const [anchorElUser, setAnchorElUser] = React.useState<null | HTMLElement>(null);
@@ -51,6 +53,7 @@ function ResponsiveAppBar() {
       if (response.status === 200) {
         setLoginUser(null);
         navigate('/');
+        enqueueSnackbar('로그아웃이 완료되었습니다', { variant: 'success' });
       }
     } catch (e) {
       window.alert('로그아웃에 실패했습니다.');

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,6 +1,7 @@
 import { useRecoilState } from 'recoil';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
+import { enqueueSnackbar } from 'notistack';
 import axios from 'axios';
 import { TextField, Button, Typography, Link, Box, Grid } from '@mui/material';
 
@@ -36,6 +37,7 @@ export default function LoginPage() {
         console.log(response);
         setLoginUser(response.data.userId);
         navigate('/main');
+        enqueueSnackbar('로그인 되었습니다', { variant: 'success' });
       }
     } catch (e) {
       if (axios.isAxiosError(e) && e.response) {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -34,7 +34,6 @@ export default function LoginPage() {
       });
 
       if (response.status === 200) {
-        console.log(response);
         setLoginUser(response.data.userId);
         navigate('/main');
         enqueueSnackbar('로그인 되었습니다', { variant: 'success' });

--- a/src/pages/team.tsx
+++ b/src/pages/team.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import axios from 'axios';
 // import { userState } from '../state/userState';
 import Grid from '@mui/material/Grid';
+import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
 
 import TeamTitle from '../components/TeamTitle';
@@ -90,9 +91,22 @@ export default function TeamPage() {
 
         <Grid item xs={4} md={4}>
           <CustomBox title="인원명단" items={memberList} />
-          <div>
-            <button onClick={() => navigate(`/team/${teamId}/schedule`)}>사적모임 일정생성</button>
-          </div>
+          <Button
+            onClick={() => navigate(`/team/${teamId}/schedule`)}
+            variant="outlined"
+            style={{
+              width: '100%',
+              maxWidth: 300,
+              borderRadius: 5,
+              border: '2px solid',
+              borderColor: 'divider',
+              backgroundColor: 'transparent',
+              marginBottom: 2,
+              color: '#696969',
+            }}
+          >
+            사적모임 일정생성
+          </Button>
         </Grid>
       </Grid>
     </Layout>

--- a/src/pages/team.tsx
+++ b/src/pages/team.tsx
@@ -1,33 +1,100 @@
+// import { useRecoilValue } from 'recoil';
 import { useParams, useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+// import { userState } from '../state/userState';
+import Grid from '@mui/material/Grid';
+import Box from '@mui/material/Box';
 
 import TeamTitle from '../components/TeamTitle';
 import TeamExp from '../components/TeamExp';
-import NoticeBox from '../components/NoticeBox';
 import { Layout } from '../components/Layout';
 import CustomBox from '../components/CustomBox';
+import { Calendar } from '../components/Calendar/Calendar';
+
+interface TeamSchedule {
+  id: number;
+  schedulename: string;
+  startTime: Date;
+  endTime: Date;
+  explanation: string;
+}
+interface TeamMember {
+  id: number;
+  name: string;
+  isAdmin: number;
+}
+interface TeamInfo {
+  teamname: string;
+  color: number;
+  explanation: string;
+  isPublic: number;
+  member: TeamMember[];
+  schedule: TeamSchedule[];
+}
 
 export default function TeamPage() {
   const params = useParams();
   const { teamId } = params;
   const navigate = useNavigate();
+  // const userId = useRecoilValue(userState); // {userId}
+
+  const [teamInfo, setTeamInfo] = useState<TeamInfo>({
+    teamname: '',
+    color: 0,
+    explanation: '',
+    isPublic: 0,
+    member: [],
+    schedule: [],
+  });
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await axios.get(`${process.env.REACT_APP_API_URL}/team/${teamId}`, {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          withCredentials: true,
+        });
+
+        if (response.status === 200) {
+          setTeamInfo({
+            teamname: response.data.teamname,
+            color: response.data.color,
+            explanation: response.data.explanation,
+            isPublic: response.data.isPublic,
+            member: response.data.members,
+            schedule: response.data.schedules,
+          });
+        }
+      } catch (e) {
+        /* empty */
+      }
+    };
+    fetchData();
+  }, [teamId]);
+
+  const memberList = teamInfo.member.map((member) => member.name);
 
   return (
     <Layout>
-      Team {teamId} Detail page
-      <TeamTitle title="KWEB" />
-      <TeamExp explanation="정보대학 웹 개발 동아리" />
-      <NoticeBox
-        notices={[
-          '1월 12일 금요일 오후 7시 30분 중간 발표 준비해주세요. 사용중인 노션 페이지랑, 와이어프레임, 다이어그램 설계 한 거 보여주고, 백엔드/프론트엔드 진행상황 설명하면 될 것 같습니다 !',
-          '1월 19일 최종발표 예정',
-        ]}
-      />
-      <CustomBox title="관리자" items={['관리자1', '관리자2']} />
-      <CustomBox title="인원명단" items={['도유진', '신정윤', '윤현지', '이원준', '탁민재']} />
-      <div>
-        <button onClick={() => navigate(`/team/${teamId}/schedule`)}>사적모임 일정생성</button>
-        <button onClick={() => navigate(`/team/${teamId}/admin`)}>공적모임 어드민</button>
-      </div>
+      <Grid container>
+        <Grid item xs={8}>
+          <TeamTitle title={teamInfo.teamname} />
+          <Box sx={{ width: '700px', height: '500px', backgroundColor: 'gray' }}>
+            <Calendar />
+          </Box>
+          <TeamExp explanation={teamInfo.explanation} />
+        </Grid>
+
+        <Grid item xs={4} md={4}>
+          <CustomBox title="인원명단" items={memberList} />
+          <div>
+            <button onClick={() => navigate(`/team/${teamId}/schedule`)}>사적모임 일정생성</button>
+          </div>
+        </Grid>
+      </Grid>
     </Layout>
   );
 }

--- a/src/pages/team.tsx
+++ b/src/pages/team.tsx
@@ -92,7 +92,13 @@ export default function TeamPage() {
         <Grid item xs={4} md={4}>
           <CustomBox title="인원명단" items={memberList} />
           <Button
-            onClick={() => navigate(`/team/${teamId}/schedule`)}
+            onClick={() => {
+              if (teamInfo.isPublic) {
+                navigate(`/team/${teamId}/admin`);
+              } else {
+                navigate(`/team/${teamId}/schedule`);
+              }
+            }}
             variant="outlined"
             style={{
               width: '100%',
@@ -105,7 +111,7 @@ export default function TeamPage() {
               color: '#696969',
             }}
           >
-            사적모임 일정생성
+            {teamInfo.isPublic ? '공적모임 어드민' : '사적모임 일정생성'}
           </Button>
         </Grid>
       </Grid>


### PR DESCRIPTION
## 추가한 점
- 사이드바에 로그인 된 유저의 팀 데이터 연동되도록 수정
- 사이드바에서 모임 글씨를 눌러도 모임 리스트가 열리게 수정
- 모임 리스트가 열릴때 아이콘 바뀌도록 수정
- 로그인 했을때와, 로그아웃 했을때 스낵바 뜨도록
- 사적 모임 메인 페이지 데이터 연동 (스케쥴 제외 !)
- 사적 모임일 시 사적 모임 생성 페이지로, 공적 모임일 시 어드민 페이지로 이동하도록 버튼 수정 

*임시로 캘린더의 크기는 width 700px, height 500px로 고정해뒀습니다
*풀화면으로 안보면 캘린더랑 인원명단 겹쳐져요 ... 

<img width="177" alt="스크린샷 2024-01-15 오후 9 43 22" src="https://github.com/KWEBofficial/anytime-client/assets/96991702/cdb31d88-dd33-42bc-9eae-baaee1691e06">

<img width="345" alt="스크린샷 2024-01-15 오후 9 44 21" src="https://github.com/KWEBofficial/anytime-client/assets/96991702/d8b9f3d1-6e95-4b32-b883-bb7884c2cd23">

