### PR TITLE
feat: favorite team component

### DIFF
--- a/src/components/FavorTeamSche/FavorTeamSche.tsx
+++ b/src/components/FavorTeamSche/FavorTeamSche.tsx
@@ -1,230 +1,203 @@
+import { useNavigate } from 'react-router-dom';
 import React, { useEffect, useState } from 'react';
 import { format } from 'date-fns';
+import axios from 'axios';
 import { Grid, Stack, List, ListItemText, Typography, ListItem, Divider } from '@mui/material';
 
 interface Schedule {
   name: string;
-  startDate: Date;
-  endDate: Date;
+  startTime: Date;
+  endTime: Date;
   explanation: string;
 }
-
-interface MyTeamSche {
+interface TeamDetail {
+  teamId: number;
   teamname: string;
-  isFavor: boolean;
-  isHide: boolean;
+  color: number;
   schedule: Schedule[];
+}
+interface TeamInfo {
+  teamId: number;
+  teamname: string;
+  isPublic: number;
+  isAdmin: number;
+  isFavor: number;
+  isHide: number;
 }
 
 export default function FavorTeamSche() {
-  const [favor, setFavor] = useState<MyTeamSche[]>([
-    {
-      teamname: 'test1',
-      isFavor: true,
-      isHide: false,
-      schedule: [
-        {
-          name: 'sche1',
-          startDate: new Date(),
-          endDate: new Date(),
-          explanation: 'sche1',
-        },
-        {
-          name: 'sche2',
-          startDate: new Date(),
-          endDate: new Date(),
-          explanation: 'sche2',
-        },
-      ],
-    },
-    {
-      teamname: 'not Favor test',
-      isFavor: false,
-      isHide: false,
-      schedule: [
-        {
-          name: 'not Favor sche1',
-          startDate: new Date(),
-          endDate: new Date(),
-          explanation: 'not Favor sche1',
-        },
-      ],
-    },
-    {
-      teamname: 'check it out',
-      isFavor: true,
-      isHide: false,
-      schedule: [
-        {
-          name: 'check11111111111111',
-          startDate: new Date('2024-01-11'),
-          endDate: new Date('2024-01-12'),
-          explanation: 'check that it should not be appeared at FavorTeam scheBox',
-        },
-        {
-          name: 'check222222222222',
-          startDate: new Date('2024-01-11'),
-          endDate: new Date('2024-01-14'),
-          explanation:
-            'Check that it should be appeared at FavorTeam scheBox. string이 칸을 넘어갈 경우 공백을 기준으로 줄바꿈이 이루어짐.',
-        },
-        {
-          name: 'check3',
-          startDate: new Date('2024-01-14'),
-          endDate: new Date('2024-01-14'),
-          explanation: 'Check that it should be appeared at FavorTeam scheBox.',
-        },
-        {
-          name: 'check4',
-          startDate: new Date('2024-01-15'),
-          endDate: new Date('2024-01-19'),
-          explanation: 'Check that it should be appeared at FavorTeam scheBox.',
-        },
-        {
-          name: 'check5',
-          startDate: new Date('2024-01-17'),
-          endDate: new Date('2024-01-17'),
-          explanation: 'Check that it should be appeared at FavorTeam scheBox.',
-        },
-        {
-          name: 'check6',
-          startDate: new Date('2024-01-22'),
-          endDate: new Date('2024-01-22'),
-          explanation: 'Check that it should be appeared at FavorTeam scheBox.',
-        },
-        {
-          name: 'check7',
-          startDate: new Date('2024-01-22'),
-          endDate: new Date('2024-01-24'),
-          explanation: 'Check that it should be appeared at FavorTeam scheBox.',
-        },
-      ],
-    },
-  ]);
+  const navigate = useNavigate();
+
+  const [myTeam, setMyTeam] = useState<TeamInfo[]>([]);
+  const [teamDetails, setTeamDetails] = useState<TeamDetail[]>([]);
+
+  const navigateToTeam = (teamId: number) => {
+    navigate(`/team/${teamId}`);
+  };
 
   useEffect(() => {
-    setFavor((curr) => curr);
-  }, []);
-  /*
-  useEffect(() => {
-    setFavor((curr) => [
-      ...curr,
-      {
-        teamname: 'test2',
-        isFavor: true,
-        isHide: false,
-        schedule: [
-          {
-            name: 'test2',
-            startDate: new Date(),
-            endDate: new Date(),
-            explanation: 'test2',
+    // 전체 팀 정보
+    const fetchData = async () => {
+      try {
+        const response = await axios.get(`${process.env.REACT_APP_API_URL}/team`, {
+          headers: {
+            'Content-Type': 'application/json',
           },
-        ],
-      },
-    ]);
+          withCredentials: true,
+        });
+
+        if (response.status === 200) {
+          setMyTeam(response.data);
+        }
+      } catch (e) {
+        /* empty */
+      }
+    };
+    fetchData();
   }, []);
-  */
-  const validTeam: MyTeamSche[] = [];
-  for (let i = 0; i < favor.length; i += 1) {
-    if (validTeam.length === 3) break;
-    if (favor[i].isFavor === true && favor[i].isHide === false) {
-      validTeam.push(favor[i]);
+
+  useEffect(() => {
+    // 즐겨찾기 팀 정보
+    const FavorTeamIds = myTeam.filter((team) => team.isFavor === 1).map((team) => team.teamId);
+
+    const fetchAllTeamsInfo = async () => {
+      await Promise.all(FavorTeamIds.map(fetchTeamInfo));
+    };
+
+    if (FavorTeamIds.length > 0) {
+      fetchAllTeamsInfo();
     }
-  }
-  const validSche = validTeam.map<MyTeamSche>((team) => {
+  }, [myTeam]);
+
+  const fetchTeamInfo = async (teamId: number) => {
+    try {
+      const response = await axios.get(`${process.env.REACT_APP_API_URL}/team/${teamId}`, {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        withCredentials: true,
+      });
+      if (response.status === 200) {
+        setTeamDetails((prevDetails) => {
+          // 이미 로드된 팀 정보를 다시 추가하지 않도록
+          if (prevDetails.some((detail) => detail.teamname === response.data.teamname)) {
+            return prevDetails;
+          }
+          const newDetails = [
+            ...prevDetails,
+            {
+              teamId,
+              teamname: response.data.teamname,
+              color: response.data.color,
+              schedule: response.data.schedules,
+            },
+          ];
+          // 팀이름 기준 정렬
+          newDetails.sort((a, b) => a.teamname.localeCompare(b.teamname));
+          return newDetails;
+        });
+      }
+    } catch (error) {
+      /* empty */
+    }
+  };
+
+  const validSche = teamDetails.map<TeamDetail>((team) => {
     return {
+      teamId: team.teamId,
       teamname: team.teamname,
-      isFavor: team.isFavor,
-      isHide: team.isHide,
+      color: team.color,
       schedule: team.schedule
         .filter((sche) => {
-          return format(sche.endDate, 'y-M-d') >= format(new Date(), 'y-M-d');
+          return format(new Date(sche.endTime), 'y-M-d') >= format(new Date(), 'y-M-d');
         })
-        .sort((a, b) => (format(a.startDate, 'y-M-d') < format(b.startDate, 'y-M-d') ? -1 : 1)),
+        .sort((a, b) => (format(new Date(a.startTime), 'y-M-d') < format(new Date(b.startTime), 'y-M-d') ? -1 : 1)),
     };
   });
 
-  const scheBox = [];
-  for (let i = 0; i < validSche.length; i += 1) {
-    scheBox.push(
-      <Grid>
-        <List
-          sx={{
-            bgcolor: '#cfe8fc',
-            width: '20vw',
-            height: '50vh',
-            borderRadius: '20px',
-            fontSize: '4vh',
-            fontWeight: 'bold',
-            boxShadow: 3,
-            overflow: 'hidden',
-            [`&.MuiList-root:hover`]: {
-              transition: '0.2s ease-in-out',
-              transform: 'scale(1.05)',
-              boxShadow: '4',
-            },
-            [`&.MuiList-root:not(:hover)`]: { transition: '0.2s ease-in-out', transfrom: 'scale(1)' },
-          }}
-        >
-          <li key={validSche[i].teamname}>
-            <ListItem>{validSche[i].teamname}</ListItem>
-
-            <Divider />
-
-            {validSche[i].schedule.map((sche) => (
-              <ListItem
-                sx={{
-                  paddingTop: 0.5,
-                  paddingBottom: 0,
-                  width: '20vw',
-                }}
-              >
-                <ListItemText
-                  primary={
-                    <Typography
-                      component="div"
-                      variant="body2"
-                      color="text.primary"
-                      width={'100%'}
-                      sx={{
-                        fontSize: '2vh',
-                        fontWeight: '800',
-                      }}
-                    >
-                      {sche.name}
-                    </Typography>
-                  }
-                  secondary={
-                    <React.Fragment>
-                      <Typography
-                        sx={{ display: 'inline', fontSize: '1.6vh', fontWeight: 'bold' }}
-                        component="div"
-                        variant="body2"
-                        color="text.primary"
-                      >
-                        {format(sche.startDate, 'y-M-d') === format(sche.endDate, 'y-M-d')
-                          ? `${format(sche.startDate, 'yy년 MM월 dd일 hh:mm')} ~ ${format(sche.endDate, 'hh:mm')}`
-                          : `${format(sche.startDate, 'yy년 MM월 dd일 hh:mm')} ~ ${format(
-                              sche.endDate,
-                              'yy년 MM월 dd일 hh:mm',
-                            )}`}
-                      </Typography>
-                      <Typography sx={{ fontSize: '1.5vh', fontWeight: 'bold' }}>{sche.explanation}</Typography>
-                    </React.Fragment>
-                  }
-                ></ListItemText>
-              </ListItem>
-            ))}
-          </li>
-        </List>
-      </Grid>,
-    );
-  }
-
   return (
     <Stack display={'flex'} justifyContent={'center'} direction={'row'} spacing={10} width={'88vw'}>
-      {scheBox}
+      <Grid container spacing={2}>
+        {validSche.map((team, index) => (
+          <Grid item xs={12} sm={6} md={4} key={index} onClick={() => navigateToTeam(team.teamId)}>
+            <List
+              sx={{
+                bgcolor: '#d3e9f6',
+                width: '20vw',
+                height: '50vh',
+                borderRadius: '20px',
+                fontSize: '4vh',
+                fontWeight: 'bold',
+                boxShadow: 3,
+                overflow: 'hidden',
+                [`&.MuiList-root:hover`]: {
+                  transition: '0.2s ease-in-out',
+                  transform: 'scale(1.05)',
+                  boxShadow: '4',
+                },
+                [`&.MuiList-root:not(:hover)`]: { transition: '0.2s ease-in-out', transfrom: 'scale(1)' },
+              }}
+            >
+              <li key={team.teamname}>
+                <ListItem>{team.teamname}</ListItem>
+                <Divider />
+
+                {team.schedule.length > 0 ? (
+                  team.schedule.map((sche, scheIndex) => (
+                    <ListItem
+                      sx={{
+                        paddingTop: 0.5,
+                        paddingBottom: 0,
+                        width: '20vw',
+                      }}
+                      key={team.teamname + scheIndex}
+                    >
+                      <ListItemText
+                        primary={
+                          <Typography
+                            component="div"
+                            variant="body2"
+                            color="text.primary"
+                            width={'100%'}
+                            sx={{
+                              fontSize: '2vh',
+                              fontWeight: '800',
+                            }}
+                          >
+                            {sche.name}
+                          </Typography>
+                        }
+                        secondary={
+                          <React.Fragment>
+                            <Typography
+                              sx={{ display: 'inline', fontSize: '1.6vh', fontWeight: 'bold' }}
+                              component="div"
+                              variant="body2"
+                              color="text.primary"
+                            >
+                              {format(sche.startTime, 'y-M-d') === format(sche.endTime, 'y-M-d')
+                                ? `${format(sche.startTime, 'yy년 MM월 dd일 hh:mm')} ~ ${format(sche.endTime, 'hh:mm')}`
+                                : `${format(sche.startTime, 'yy년 MM월 dd일 hh:mm')} ~ ${format(
+                                    sche.endTime,
+                                    'yy년 MM월 dd일 hh:mm',
+                                  )}`}
+                            </Typography>
+                            <Typography sx={{ fontSize: '1.5vh', fontWeight: 'bold' }}>{sche.explanation}</Typography>
+                          </React.Fragment>
+                        }
+                      ></ListItemText>
+                    </ListItem>
+                  ))
+                ) : (
+                  <ListItem>
+                    <Typography sx={{ fontSize: '2vh' }}>예정된 일정이 없어요</Typography>
+                  </ListItem>
+                )}
+              </li>
+            </List>
+          </Grid>
+        ))}
+      </Grid>
     </Stack>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,11 +1,9 @@
 import { useNavigate } from 'react-router-dom';
 import * as React from 'react';
-// import Typography from '@mui/material/Typography';
 import { useEffect, useState } from 'react';
 import axios from 'axios';
 import Toolbar from '@mui/material/Toolbar';
 import ListItemText from '@mui/material/ListItemText';
-// import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItem from '@mui/material/ListItem';
@@ -16,8 +14,8 @@ import CssBaseline from '@mui/material/CssBaseline';
 import Collapse from '@mui/material/Collapse';
 import Box from '@mui/material/Box';
 import AppBar from '@mui/material/AppBar';
-// import InboxIcon from '@mui/icons-material/MoveToInbox';
-// import MailIcon from '@mui/icons-material/Mail';
+import StarRoundedIcon from '@mui/icons-material/StarRounded';
+import StarBorderRoundedIcon from '@mui/icons-material/StarBorderRounded';
 import SearchIcon from '@mui/icons-material/Search';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
@@ -40,6 +38,8 @@ export default function ClippedDrawer() {
   const [openPrivate, setOpenPrivate] = useState(false);
   const [openPublic, setOpenPublic] = useState(false);
   const [myTeam, setMyTeam] = useState<TeamInfo[]>([]);
+  const [publicIsFavor, setPublicIsFavor] = useState<number[]>([]);
+  const [privateIsFavor, setPrivateIsFavor] = useState<number[]>([]);
 
   const handlePrivateClick = () => {
     setOpenPrivate(!openPrivate);
@@ -64,7 +64,17 @@ export default function ClippedDrawer() {
         });
 
         if (response.status === 200) {
-          setMyTeam(response.data);
+          const { data } = response;
+          setMyTeam(data);
+
+          const initialPublicIsFavor = data
+            .filter((team: TeamInfo) => team.isPublic === 1)
+            .map((team: TeamInfo) => (team.isFavor === 1 ? 1 : 0));
+          const initialPrivateIsFavor = data
+            .filter((team: TeamInfo) => team.isPublic === 0)
+            .map((team: TeamInfo) => (team.isFavor === 1 ? 1 : 0));
+          setPublicIsFavor(initialPublicIsFavor);
+          setPrivateIsFavor(initialPrivateIsFavor);
         }
       } catch (e) {
         /* empty */
@@ -77,6 +87,36 @@ export default function ClippedDrawer() {
   const publicTeamIds = myTeam.filter((team) => team.isPublic === 1).map((team) => team.teamId);
   const privateTeamNames = myTeam.filter((team) => team.isPublic === 0).map((team) => team.teamname);
   const privateTeamIds = myTeam.filter((team) => team.isPublic === 0).map((team) => team.teamId);
+
+  const toggleFavor = async (teamId: number) => {
+    // 별 눌렀을때 patch 요청 보내기
+    try {
+      await axios.patch(
+        `${process.env.REACT_APP_API_URL}/team/favorite/${teamId}`,
+        {},
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          withCredentials: true,
+        },
+      );
+    } catch (e) {
+      /* empty */
+    }
+  };
+
+  // 별 모양 변경을 위한 함수
+  const togglePrivateFavor = (index: number) => {
+    const updatedIsFavor = [...privateIsFavor];
+    updatedIsFavor[index] = updatedIsFavor[index] === 0 ? 1 : 0;
+    setPrivateIsFavor(updatedIsFavor);
+  };
+  const togglePublicFavor = (index: number) => {
+    const updatedIsFavor = [...publicIsFavor];
+    updatedIsFavor[index] = updatedIsFavor[index] === 0 ? 1 : 0;
+    setPublicIsFavor(updatedIsFavor);
+  };
 
   return (
     <Box sx={{ display: 'flex' }}>
@@ -126,6 +166,15 @@ export default function ClippedDrawer() {
                       onClick={() => navigateToTeam(privateTeamIds[index])}
                     >
                       <ListItemText primary={name} />
+                      <div
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          toggleFavor(privateTeamIds[index]);
+                          togglePrivateFavor(index);
+                        }}
+                      >
+                        {privateIsFavor[index] ? <StarRoundedIcon /> : <StarBorderRoundedIcon />}
+                      </div>
                     </ListItemButton>
                   ))}
                 </Collapse>
@@ -158,6 +207,15 @@ export default function ClippedDrawer() {
                       onClick={() => navigateToTeam(publicTeamIds[index])}
                     >
                       <ListItemText primary={name} />
+                      <div
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          toggleFavor(publicTeamIds[index]);
+                          togglePublicFavor(index);
+                        }}
+                      >
+                        {publicIsFavor[index] ? <StarRoundedIcon /> : <StarBorderRoundedIcon />}
+                      </div>
                     </ListItemButton>
                   ))}
                 </Collapse>
@@ -169,25 +227,3 @@ export default function ClippedDrawer() {
     </Box>
   );
 }
-
-/*
-      <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
-        <ResponsiveAppBar />
-      </AppBar>
-*/
-
-/*
-      <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
-        <Toolbar />
-        <Typography paragraph>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
-          magna aliqua. Rhoncus dolor purus non enim praesent elementum facilisis leo vel. Risus at ultrices mi tempus
-          imperdiet. Semper risus in hendrerit gravida rutrum quisque non tellus. Convallis convallis tellus id interdum
-          velit laoreet id donec ultrices. Odio morbi quis commodo odio aenean sed adipiscing. Amet nisl suscipit
-          adipiscing bibendum est ultricies integer quis. Cursus euismod quis viverra nibh cras. Metus vulputate eu
-          scelerisque felis imperdiet proin fermentum leo. Mauris commodo quis imperdiet massa tincidunt. Cras tincidunt
-          lobortis feugiat vivamus at augue. At augue eget arcu dictum varius duis at consectetur lorem. Velit sed
-          ullamcorper morbi tincidunt. Lorem donec massa sapien faucibus et molestie ac.
-        </Typography>
-      </Box>
-*/

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,5 +1,11 @@
 import { Layout } from '../components/Layout';
+import FavorTeamSche from '../components/FavorTeamSche/FavorTeamSche';
 
 export default function MainPage() {
-  return <Layout>Main</Layout>;
+  return (
+    <Layout>
+      Main
+      <FavorTeamSche />
+    </Layout>
+  );
 }

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,4 +1,3 @@
-
 import { useRecoilValue } from 'recoil';
 
 import { userState } from '../state/userState';
@@ -9,7 +8,6 @@ export default function MyPage() {
   return (
     <Layout>
       <div>현재 유저 id: {userId}</div>MyPage
-
     </Layout>
   );
 }


### PR DESCRIPTION
## 추가한 점 
1. 팀 즐겨찾기 기능
- 사이드바에서 팀 옆에 있는 별을 클릭하면 즐겨찾기 팀으로 등록됩니다.

2. 메인페이지의 즐겨찾기 된 팀 컴포넌트

기존의 favorite team schedule 컴포넌트 코드 수정
- 기존 코드에서 일부 데이터 타입을 변경하고, format 오류를 수정했습니다
- 기존 코드에서 팀의 ishide 속성을 받아오게 되어있는데, 저희 서버 코드에 팀 정보 조회에서 ishide를 받아오지 않아서 이부분은 없앴습니다. 지금은 팀을 숨기더라도 즐겨찾기 되었다면 보이게 되어 있어요!

(원준님 위에서 설명한거 이외에 기존 코드 의도와 다르게 변경된 게 있다면 말씀해주세용)
 
- 일단 데이터 받아올때 팀 색상도 받아오게 했습니다. 나중에 디자인 수정할때 사용해도 될 것 같아요 !
- 즐겨찾기 팀은 이름 순으로 정렬되며, 일정이 없는 팀의 경우 예정된 일정이 없어요 라는 문구를 띄우도록 했습니다.
- 컴포넌트 클릭하면 해당 팀 페이지로 이동하게 했는데 어떠신지 의견 주세요 ..!

<img width="703" alt="스크린샷 2024-01-17 오후 5 32 43" src="https://github.com/KWEBofficial/anytime-client/assets/96991702/cba11559-b6e3-45b9-b94a-a08495ce7e3f">

## 논의할 점
- 사이드바에서 즐겨찾기를 추가하더라도 메인 페이지에서 즐겨찾기 컴포넌트가 즉각적으로 생기진 않아요. 새로고침 하면 생기긴 하는데 바로 재렌더링 되도록 해야 할까요 ..