### PR TITLE
feat: teamtitleContext, calendarContext 구현 및 schedule 모달 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,9 +5,10 @@ import { ThemeProvider, createTheme } from '@mui/material';
 
 import { RouteComponent } from './route';
 import './App.css';
+import { TeamTitleProvider } from './contexts/teamTitleContext';
 import { SidebarProvider } from './contexts/sidebarContext';
-
-// import { ModalContextProvider } from './components/Modal/useModal';
+import { CalenderProvider } from './contexts/calenderContext';
+import { ModalContextProvider } from './components/Modal/useModal';
 
 /**
  * mui에서 제공하는 테마 설정입니다.
@@ -27,50 +28,24 @@ const theme = createTheme({
  */
 function App() {
   return (
-    <SidebarProvider>
-      <SnackbarProvider maxSnack={3}>
-        <RecoilRoot>
-          <ThemeProvider theme={theme}>
-            <BrowserRouter>
-              <RouteComponent />
-            </BrowserRouter>
-          </ThemeProvider>
-        </RecoilRoot>
-      </SnackbarProvider>
-    </SidebarProvider>
+    <ModalContextProvider>
+      <CalenderProvider>
+        <SidebarProvider>
+          <TeamTitleProvider>
+            <SnackbarProvider maxSnack={3}>
+              <RecoilRoot>
+                <ThemeProvider theme={theme}>
+                  <BrowserRouter>
+                    <RouteComponent />
+                  </BrowserRouter>
+                </ThemeProvider>
+              </RecoilRoot>
+            </SnackbarProvider>
+          </TeamTitleProvider>
+        </SidebarProvider>
+      </CalenderProvider>
+    </ModalContextProvider>
   );
-
-  /*
-
-    <ThemeProvider theme={theme}>
-      <BrowserRouter>
-        <RouteComponent />
-        <ModalContextProvider>
-          <Examples />
-        </ModalContextProvider>
-        <FormDialog />
-        <Alarm />
-
-        
-           <ModalContextProvider>
-            <Examples />
-          </ModalContextProvider>
-          <div>
-            <button onClick={openModal}>Open Modal</button>
-            <CustomModal isOpen={open} closeModal={closeModal}>
-              <Box>
-                <Typography variant="h6" component="h2">
-                  hi
-                </Typography>
-                <Typography sx={{ mt: 2 }}>it's me</Typography>
-              </Box>
-            </CustomModal>
-          </div>
- 
-      </BrowserRouter>
-    </ThemeProvider>
-
-    */
 }
 
 export default App;

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -24,6 +24,7 @@ import ArrowCircleLeftSharpIcon from '@mui/icons-material/ArrowCircleLeftSharp';
 import './style.scss';
 import { useModal } from '../Modal/useModal';
 import { ScheType, CalendarProps } from '../../models/calendar';
+import { useCalender } from '../../contexts/calenderContext';
 
 interface RenderHeaderProps {
   currentMonth: Date;
@@ -221,6 +222,7 @@ export const Calendar = ({ isEditable, height, width, schedules, isMyPage }: Cal
   const { openAlert, openSchedulePrompt } = useModal();
   const params = useParams();
   const { teamId } = params;
+  const { refreshCalender } = useCalender();
 
   const prevMonth = () => {
     setCurrentMonth(subMonths(currentMonth, 1));
@@ -230,7 +232,7 @@ export const Calendar = ({ isEditable, height, width, schedules, isMyPage }: Cal
   };
   const onDateClick = (day: Date) => {
     setSelectedDate(day);
-    if (isEditable) createScheduleModal();
+    if (isEditable) createScheduleModal(day);
   };
 
   async function createSchedule(scheName: string, explanation: string, startTime: Date, endTime: Date) {
@@ -251,6 +253,7 @@ export const Calendar = ({ isEditable, height, width, schedules, isMyPage }: Cal
       );
       if (response.status === 200) {
         enqueueSnackbar('일정이 추가되었습니다.', { variant: 'success' });
+        refreshCalender();
       }
     } catch (e) {
       enqueueSnackbar('일정 추가에 실패하였습니다.', { variant: 'error' });
@@ -265,7 +268,6 @@ export const Calendar = ({ isEditable, height, width, schedules, isMyPage }: Cal
     scheduleId: number,
   ) {
     try {
-      console.log(scheduleId);
       const response = await axios.patch(
         `${process.env.REACT_APP_API_URL}/schedule/${scheduleId}`,
         { name: scheName, startTime, endTime, explanation },
@@ -278,6 +280,7 @@ export const Calendar = ({ isEditable, height, width, schedules, isMyPage }: Cal
       );
       if (response.status === 200) {
         enqueueSnackbar('일정이 수정되었습니다.', { variant: 'success' });
+        refreshCalender();
       }
     } catch (e) {
       enqueueSnackbar('일정 수정에 실패하였습니다.', { variant: 'error' });
@@ -294,16 +297,19 @@ export const Calendar = ({ isEditable, height, width, schedules, isMyPage }: Cal
       });
       if (response.status === 200) {
         enqueueSnackbar('일정이 삭제되었습니다.', { variant: 'success' });
+        refreshCalender();
       }
     } catch (e) {
       enqueueSnackbar('일정 삭제에 실패하였습니다..', { variant: 'error' });
     }
   }
 
-  const createScheduleModal = () => {
+  const createScheduleModal = (clickDay: Date) => {
     openSchedulePrompt({
       isEmpty: true,
       isEditable,
+      startDate: clickDay,
+      endDate: clickDay,
       onSubmit: (title, content, startTime, endTime) => {
         if (startTime != null && endTime != null) createSchedule(title, content, startTime.toDate(), endTime.toDate());
         else openAlert({ title: '일정 생성 실패', message: '일정의 시작과 끝을 입력해주세요' });

--- a/src/components/Modal/Prompt/Schedule.tsx
+++ b/src/components/Modal/Prompt/Schedule.tsx
@@ -112,8 +112,15 @@ const SchedulePrompt = ({
                 label="시작 날짜/시간"
                 value={start}
                 onChange={handleStartChange}
+                defaultValue={dayjs(startDate)}
               />
-              <DateTimePicker sx={{ width: '100%' }} label="종료 날짜/시간" value={end} onChange={handleEndChange} />
+              <DateTimePicker
+                sx={{ width: '100%' }}
+                label="종료 날짜/시간"
+                value={end}
+                onChange={handleEndChange}
+                defaultValue={dayjs(startDate)}
+              />
             </LocalizationProvider>
 
             <Stack direction="row" justifyContent="flex-end" alignItems="flex-end" spacing={2}>

--- a/src/components/TeamTitle.tsx
+++ b/src/components/TeamTitle.tsx
@@ -9,6 +9,7 @@ import AppBar from '@mui/material/AppBar';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 
+import { useTeamTitle } from '../contexts/teamTitleContext';
 import { useSidebar } from '../contexts/sidebarContext';
 
 import { useModal } from './Modal/useModal';
@@ -25,6 +26,7 @@ export default function TeamTitle({ title, teamId, isAdmin, isPublic, onClick }:
   const { openPrompt, openConfirm } = useModal();
   const navigate = useNavigate();
   const { refresh } = useSidebar();
+  const { refreshTitle } = useTeamTitle();
 
   async function editTeamFunc(teamname: string, explanation: string, color: string) {
     try {
@@ -41,6 +43,8 @@ export default function TeamTitle({ title, teamId, isAdmin, isPublic, onClick }:
       if (response.status === 200) {
         enqueueSnackbar('모임 정보가 수정되었습니다.', { variant: 'success' });
         refresh();
+        refreshTitle();
+        console.log(refreshTitle);
       }
     } catch (e) {
       enqueueSnackbar('모임 정보 수정에 실패하였습니다..', { variant: 'error' });

--- a/src/contexts/calenderContext.tsx
+++ b/src/contexts/calenderContext.tsx
@@ -1,0 +1,17 @@
+import React, { createContext, useState, useContext, PropsWithChildren } from 'react';
+
+const CalenderContext = createContext<{ refreshCalender: () => void }>({
+  refreshCalender: () => {},
+});
+
+export const useCalender = () => useContext(CalenderContext);
+
+export const CalenderProvider: React.FC<PropsWithChildren<unknown>> = ({ children }) => {
+  const [, setRefreshCalender] = useState({});
+
+  const refreshCalender = () => {
+    setRefreshCalender({});
+  };
+
+  return <CalenderContext.Provider value={{ refreshCalender }}>{children}</CalenderContext.Provider>;
+};

--- a/src/contexts/teamTitleContext.tsx
+++ b/src/contexts/teamTitleContext.tsx
@@ -1,0 +1,17 @@
+import React, { createContext, useState, useContext, PropsWithChildren } from 'react';
+
+const TeamTitleContext = createContext<{ refreshTitle: () => void }>({
+  refreshTitle: () => {},
+});
+
+export const useTeamTitle = () => useContext(TeamTitleContext);
+
+export const TeamTitleProvider: React.FC<PropsWithChildren<unknown>> = ({ children }) => {
+  const [, setRefreshTitle] = useState({});
+
+  const refreshTitle = () => {
+    setRefreshTitle({});
+  };
+
+  return <TeamTitleContext.Provider value={{ refreshTitle }}>{children}</TeamTitleContext.Provider>;
+};

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -8,6 +8,8 @@ import Button from '@mui/material/Button';
 
 import { userState } from '../state/userState';
 import { ScheType } from '../models/calendar';
+import { useTeamTitle } from '../contexts/teamTitleContext';
+import { useCalender } from '../contexts/calenderContext';
 import TeamTitle from '../components/TeamTitle';
 import TeamExp from '../components/TeamExp';
 import { Layout } from '../components/Layout';
@@ -59,6 +61,9 @@ export default function AdminPage() {
     notices: [],
     isAdmin: false,
   });
+  const { refreshTitle } = useTeamTitle();
+  const { refreshCalender } = useCalender();
+
   const handleDeleteClick = async () => {
     const fetchData = async () => {
       await axios.delete(`${process.env.REACT_APP_API_URL}/team/${teamId}`, {
@@ -137,7 +142,7 @@ export default function AdminPage() {
       }
     };
     fetchData();
-  }, []);
+  }, [refreshTitle, refreshCalender]);
 
   useEffect(() => {
     setSche(

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -5,8 +5,8 @@ import { Grid, Typography } from '@mui/material';
 
 import { userState } from '../state/userState';
 import { AllScheSearchDTO } from '../models/AllScheSearch';
+import { useCalender } from '../contexts/calenderContext';
 import TeamShowBox from '../components/TeamShowBox/TeamShowBox';
-// import { useModal } from '../components/Modal/useModal';
 import { Layout } from '../components/Layout';
 import { Calendar } from '../components/Calendar/Calendar';
 
@@ -27,22 +27,7 @@ export default function MyPage() {
     mySchedules: [],
     teamSchedules: [],
   });
-  /*
-  const { openAlert, openSchedulePrompt } = useModal();
-  
-  const editSchedule = (Sche: ScheType) => {
-    if (Sche.teamId)
-      openSchedulePrompt({
-        isEmpty: false,
-        onSubmit: (title, content, start, end) => {
-          openAlert({
-            title: '일정이 수정되었습니다',
-            message: `${title} ${content} ${start} ${end} `,
-          });
-        },
-      });
-  };
-  */
+  const { refreshCalender } = useCalender();
 
   useEffect(() => {
     const fetchData = async () => {
@@ -82,7 +67,7 @@ export default function MyPage() {
       }
     };
     fetchData();
-  }, []);
+  }, [refreshCalender]);
 
   useEffect(() => {
     setSche(() => [

--- a/src/pages/team.tsx
+++ b/src/pages/team.tsx
@@ -1,12 +1,12 @@
-// import { useRecoilValue } from 'recoil';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import axios from 'axios';
-// import { userState } from '../state/userState';
 import Grid from '@mui/material/Grid';
 import Button from '@mui/material/Button';
 
 import { ScheType } from '../models/calendar';
+import { useTeamTitle } from '../contexts/teamTitleContext';
+import { useCalender } from '../contexts/calenderContext';
 import TeamTitle from '../components/TeamTitle';
 import TeamScheduleList from '../components/TeamSchduleList/TeamScheduleList';
 import TeamExp from '../components/TeamExp';
@@ -74,6 +74,9 @@ export default function TeamPage() {
     isAdmin: true,
   });
 
+  const { refreshTitle } = useTeamTitle();
+  const { refreshCalender } = useCalender();
+
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -101,7 +104,7 @@ export default function TeamPage() {
       }
     };
     fetchData();
-  }, [teamId]);
+  }, [teamId, refreshTitle, refreshCalender]);
 
   useEffect(() => {
     setSche(


### PR DESCRIPTION
- 모임 수정, 일정 생성 및 수정 시 새로 고침 없이 캘린더와 타이틀에 바로 반영
- 캘린더에서 클릭한 날짜가 모달 날짜 선택에 반영되도록 수정